### PR TITLE
Remove default copy constructor of DebugStream

### DIFF
--- a/include/quick/debug_stream.hpp
+++ b/include/quick/debug_stream.hpp
@@ -33,7 +33,6 @@ class DebugStream {
  public:
   std::ostringstream oss;
   DebugStream() = default;
-  DebugStream(const DebugStream&) = default;
   template<typename... Ts>
   explicit DebugStream(const Ts&... input) {
     this->Consume(input...);


### PR DESCRIPTION
`std::ostringstream` has a deleted copy constructor. `DebugStream` has a member variable `oss` of type `std::ostringstream`. A default copy constructor results in a compilation error.

The copy constructor is not correctly used, and therefore should be safe to delete.

Reference: http://www.cplusplus.com/reference/sstream/ostringstream/ostringstream/

cc @mohit-saini 